### PR TITLE
Rarity Chart & Playground Back To Composite Button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,3 @@
 
 # vercel
 .vercel
-
-# traits (keep folder)
-traits/*.png

--- a/pages/projects/[projectId]/collections/[collectionId]/composites/[compositeGroupId]/playground.tsx
+++ b/pages/projects/[projectId]/collections/[collectionId]/composites/[compositeGroupId]/playground.tsx
@@ -189,7 +189,7 @@ export default function CreatePage(props: Props) {
               type="button"
               className="inline-flex items-center mr-2 px-3 py-1 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
             >
-              Back To Composite
+              Back to Composite Group
             </button>
           </a>
         </Link>

--- a/pages/projects/[projectId]/collections/[collectionId]/composites/[compositeGroupId]/rarity.tsx
+++ b/pages/projects/[projectId]/collections/[collectionId]/composites/[compositeGroupId]/rarity.tsx
@@ -88,7 +88,7 @@ export default function IndexPage(props: Props) {
                     type="button"
                     className="inline-flex items-center mr-2 px-3 py-1 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
                   >
-                    Back To Composite
+                    Back to Composite Group
                   </button>
                 </a>
               </Link>


### PR DESCRIPTION
I wanted an easier way to get back to the composite screen from the rarity chart and the composite playground, so I added a back button in the top right corner of both pages.

I also added a git ignore entry so we can keep the traits folder, but not upload the image files.

I also added a prettier config to keep consistent with your patterns. 