### PR TITLE
Add `excludeFromDuplicateDetection` flag to traits

### DIFF
--- a/functions/models/models.ts
+++ b/functions/models/models.ts
@@ -19,6 +19,7 @@ export interface Trait {
   name: string;
   zIndex: number;
   isMetadataOnly: boolean;
+  excludeFromDuplicateDetection: boolean;
 }
 
 export interface TraitValue {
@@ -130,7 +131,11 @@ export namespace ImageComposites {
         return zIndexA < zIndexB ? -1 : zIndexA == zIndexB ? 0 : 1;
       })
       .reduce(function (result, traitPair) {
-        if (traitPair.trait.isMetadataOnly || traitPair.traitValue == null) {
+        if (
+          traitPair.trait.isMetadataOnly ||
+          traitPair.trait.excludeFromDuplicateDetection ||
+          traitPair.traitValue == null
+        ) {
           return result;
         }
 

--- a/models/trait.tsx
+++ b/models/trait.tsx
@@ -19,6 +19,7 @@ export default interface Trait {
   name: string;
   zIndex: number;
   isMetadataOnly: boolean;
+  excludeFromDuplicateDetection: boolean;
 }
 
 export namespace Traits {

--- a/pages/projects/[projectId]/collections/[collectionId]/traits/create.tsx
+++ b/pages/projects/[projectId]/collections/[collectionId]/traits/create.tsx
@@ -36,11 +36,14 @@ export default function CreatePage(props: Props) {
     const zIndex = zIndexStr ? parseInt(zIndexStr) : 0;
 
     const isMetadataOnly = data.get("isMetadataOnly")?.toString() == "1";
+    const excludeFromDuplicateDetection =
+      data.get("excludeFromDuplicateDetection")?.toString() == "1";
 
     const trait = {
       name: name,
       zIndex: zIndex,
       isMetadataOnly: isMetadataOnly,
+      excludeFromDuplicateDetection: excludeFromDuplicateDetection,
     } as Trait;
 
     await Traits.create(trait, projectId, collection.id);
@@ -130,6 +133,27 @@ export default function CreatePage(props: Props) {
                       <p className="text-xs text-gray-600 mt-2">
                         Check this box if this is a trait with no associated
                         artwork (ex. a name)
+                      </p>
+                    </div>
+
+                    <div>
+                      <input
+                        type="checkbox"
+                        name="excludeFromDuplicateDetection"
+                        id="excludeFromDuplicateDetection"
+                        className="shadow-sm sm:text-sm rounded-md border-transparent inline-block mr-2"
+                        value="1"
+                      />
+                      <label
+                        htmlFor="excludeFromDuplicateDetection"
+                        className="inline-block text-sm font-medium"
+                      >
+                        Exclude from duplicate detection?
+                      </label>
+                      <p className="text-xs text-gray-600 mt-2">
+                        Check this box if this is a trait that should not be
+                        included when determining uniqueness when detecting
+                        duplicates (ex. background colour)
                       </p>
                     </div>
                   </div>

--- a/pages/projects/[projectId]/collections/[collectionId]/traits/index.tsx
+++ b/pages/projects/[projectId]/collections/[collectionId]/traits/index.tsx
@@ -186,6 +186,12 @@ export default function IndexPage(props: Props) {
                           <th
                             scope="col"
                             className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                          >
+                            Exclude from duplicate detection?
+                          </th>
+                          <th
+                            scope="col"
+                            className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
                           ></th>
                         </tr>
                       </thead>
@@ -232,6 +238,13 @@ export default function IndexPage(props: Props) {
                               <td className="px-6 py-4" width="100">
                                 <div className="text-sm text-gray-500 overflow-ellipsis">
                                   {trait?.isMetadataOnly ? "yes" : "no"}
+                                </div>
+                              </td>
+                              <td className="px-6 py-4" width="100">
+                                <div className="text-sm text-gray-500 overflow-ellipsis">
+                                  {trait?.excludeFromDuplicateDetection
+                                    ? "yes"
+                                    : "no"}
                                 </div>
                               </td>
                               <td align="right" width="100">


### PR DESCRIPTION
Add a flag to exclude traits from the traits hash used to detect
duplicates. A common use case would be to exclude background colour when
determining uniqueness as suggested by here: https://twitter.com/solbigbrain/status/1451979433540214791?s=21