### PR TITLE
Add npm script for starting Firebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@
 
 # vercel
 .vercel
+
+functions/backup/*

--- a/README.md
+++ b/README.md
@@ -129,16 +129,13 @@ y [Yes]
 
 ```bash
 npm install --prefix=functions
-npm run build --prefix=functions
-
-# IMPORTANT: 
-# when starting the firebase emulators, specify a directory you have access to
-# to save your work. for ex. to save to a folder called "backup" use the 
-# firebase command below with import and export-on-exit params as shown:  
-firebase emulators:start --import backup --export-on-exit backup
+# This builds the functions and starts the emulator set up to save to a folder called "backup" under the "functions" folder.
+npm run serve --prefix=functions
 ```
 
-**_Note_**: _If the emulators fail to start, see `firestore-debug.log`. One common cause for failure is that you may need to install the [java runtime](http://www.java.com.)_
+**_Notes_**: _If you have been using a older version of Treat Toolbox, your backup may be in a different location. You can move the folder under the `functions` folder when the emulator isn't running._
+
+_If the emulators fail to start, see `firestore-debug.log`. One common cause for failure is that you may need to install the [java runtime](http://www.java.com.)_
 
 11. When the emulators start, the API url for your cloud functions will be output in the form:
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "functions",
   "scripts": {
     "build": "tsc",
-    "serve": "npm run build && firebase emulators:start --import ~/.firebase-data",
+    "serve": "npm run build && firebase emulators:start --import backup --export-on-exit backup",
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",
     "watch": "tsc -w",


### PR DESCRIPTION
Updates the npm `serve` script under the `functions` folder so that it:
- builds Firebase functions (saves explicitly re-building when updating)
- starts the Firebase emulator with import from the `backup` folder and export on exit to the `backup` folder

The README instructions have been updated to have users start Firebase emulator using this new script.