### PR TITLE
Remove hardcoded batches limit

### DIFF
--- a/pages/projects/[projectId]/collections/[collectionId]/composites/[compositeGroupId]/index.tsx
+++ b/pages/projects/[projectId]/collections/[collectionId]/composites/[compositeGroupId]/index.tsx
@@ -71,7 +71,7 @@ export default function IndexPage(props: Props) {
 
     const urls: string[] = [];
 
-    for (let i = 0; i < composites.length / BATCH_SIZE && i < 2; i++) {
+    for (let i = 0; i < composites.length / BATCH_SIZE; i++) {
       setExportedItems(i * BATCH_SIZE);
 
       const response = await fetch(


### PR DESCRIPTION
There was an hardcoded limit to the number of batches that could be generated.
No more than 2 batches could be generated.
Probably some debugging code that hasn't been removed before commit.