### PR TITLE
Default values for `traitSetIds`

### DIFF
--- a/components/Forms/Trait/index.tsx
+++ b/components/Forms/Trait/index.tsx
@@ -39,7 +39,7 @@ export const TraitForm: React.FC<Props> = ({
     formState: { errors },
   } = useForm<Trait>({
     resolver: yupResolver(schema),
-    defaultValues: trait ?? {},
+    defaultValues: trait ?? { traitSetIds: [] },
   });
 
   const router = useRouter();

--- a/components/Forms/Trait/index.tsx
+++ b/components/Forms/Trait/index.tsx
@@ -227,7 +227,7 @@ export const TraitForm: React.FC<Props> = ({
                       <input
                         type="checkbox"
                         id={"traitSet-" + traitSet.id}
-                        {...register(`traitSetIds`)}
+                        {...register(`traitSetIds`, { value: [] })}
                         className="traitSetCheckbox shadow-sm sm:text-sm rounded-md border-transparent inline-block mr-2"
                         defaultChecked={trait?.traitSetIds?.includes(
                           traitSet.id


### PR DESCRIPTION
fixes theskeletoncrew/treat-toolbox#48, somewhat.

prior to this, any traits created with the "create trait" form would omit the `traitSetIds` property, which caused issues enumerated in the above issue where going from 0->1 trait sets would cause certain pages to fail. this failure was due to the Trait type looking like: `{... traitSetIds: String[] }` but actually coming back from the API like `{ traitSetIds: false }` or not having the property at all.

this PR ensures that traits that are created when no traitSets exist will have the `traitSetIds` field set to an empty array, and for traits that are created but have no traitSets selected will still initialize to an empty array.

unfortunately, this is not a retroactive fix since the database will still be surfacing Trait models that either omit this property, or have already stored the `traitSetIds: false`. poking around a bit to see if there's a way to handle this on read, but this should at least stop new projects from failing hard with trait sets.