### PR TITLE
Traits Form: checkboxes should be evaluated as booleans

### DIFF
--- a/components/Forms/Trait/index.tsx
+++ b/components/Forms/Trait/index.tsx
@@ -22,6 +22,10 @@ const schema = yup
       .typeError("Must be a positive number")
       .positive("Must be a positive number")
       .required("This field is required"),
+    excludeFromDuplicateDetection: yup.boolean(),
+    isMetadataOnly: yup.boolean(),
+    isArtworkOnly: yup.boolean(),
+    isAlwaysUnique: yup.boolean(),
   })
   .required();
 


### PR DESCRIPTION
Checkboxes were not explicitly marked to be evaluated as booleans which could lead to `"1"` rather than `true` as database entries.