### PR TITLE
Add environment variables for batch sizes

### DIFF
--- a/pages/projects/[projectId]/collections/[collectionId]/composites/[compositeGroupId]/index.tsx
+++ b/pages/projects/[projectId]/collections/[collectionId]/composites/[compositeGroupId]/index.tsx
@@ -26,7 +26,7 @@ interface Props {
   userGroupId: string;
 }
 
-const BATCH_SIZE = 500;
+const BATCH_SIZE = Number(process.env.NEXT_PUBLIC_EXPORT_BATCH_SIZE ?? 500);
 
 export default function IndexPage(props: Props) {
   const project = props.project;

--- a/pages/projects/[projectId]/collections/[collectionId]/composites/index.tsx
+++ b/pages/projects/[projectId]/collections/[collectionId]/composites/index.tsx
@@ -34,7 +34,7 @@ export default function IndexPage(props: Props) {
   const compositesCountDict = props.compositesCountDict;
   const projectId = props.projectId;
 
-  const BATCH_SIZE = 100;
+  const BATCH_SIZE = Number(process.env.NEXT_PUBLIC_GENERATE_BATCH_SIZE ?? 100);
 
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [generatingModalOpen, setGeneratingModalOpen] = useState(false);


### PR DESCRIPTION
Composite generation and export batch sizes can now be configured using:
- `NEXT_PUBLIC_GENERATE_BATCH_SIZE` (default: 100)
- `NEXT_PUBLIC_EXPORT_BATCH_SIZE` (default: 500)