### PR TITLE
Fix undefined Traits Set ID

### DIFF
--- a/pages/projects/[projectId]/collections/[collectionId]/artwork/index.tsx
+++ b/pages/projects/[projectId]/collections/[collectionId]/artwork/index.tsx
@@ -252,7 +252,7 @@ export default function IndexPage(props: Props) {
 
           ImageLayers.update(
             {
-              traitSetId: traitSet?.id,
+              traitSetId: traitSet?.id || -1,
               traitId: trait.id,
               traitValueId: traitValue.id,
             },


### PR DESCRIPTION
Fix undefined Traits Set ID when syncing the Artworks with the Traits without using any Traits Set.

I was getting the following error when not using any Traits Set but everything was working fine when using Traits Set.

![image](https://user-images.githubusercontent.com/92687072/160259064-459ba080-a8a5-44b5-a78b-9dde7f359795.png)