### PR TITLE
Fix undefined Traits Set ID

### DIFF
--- a/pages/projects/[projectId]/collections/[collectionId]/artwork/index.tsx
+++ b/pages/projects/[projectId]/collections/[collectionId]/artwork/index.tsx
@@ -252,7 +252,7 @@ export default function IndexPage(props: Props) {
 
           ImageLayers.update(
             {
-              traitSetId: traitSet?.id,
+              traitSetId: traitSet?.id || "-1",
               traitId: trait.id,
               traitValueId: traitValue.id,
             },


### PR DESCRIPTION
Fix undefined Traits Set ID when syncing the Artworks with the Traits without using any Traits Set.

Thanks for the community contribution @Auraze. This closes #62 and
ensures the argument type is correctly defined as a string.

Co-authored-by: Auraze <92687072+Auraze@users.noreply.github.com>