### PR TITLE
dynamically update total and none rarity when trait values edited inline

### DIFF
--- a/components/TraitValuesRow/index.tsx
+++ b/components/TraitValuesRow/index.tsx
@@ -4,34 +4,39 @@ import TraitValue, { TraitValues } from "../../models/traitValue";
 import Trait from "../../models/trait";
 
 interface Props {
-  traitValue: TraitValue,
-  projectId: string,
-  collectionId: string,
-  trait: Trait
+  traitValue: TraitValue;
+  projectId: string;
+  collectionId: string;
+  trait: Trait;
+  handleTraitValueChange: (data: TraitValue) => void;
 }
 
 export const TraitValuesRow: React.FC<Props> = ({
-    traitValue,
-    projectId,
-    collectionId,
-    trait,
+  traitValue,
+  projectId,
+  collectionId,
+  trait,
+  handleTraitValueChange,
 }) => {
   const [newValue, setNewValue] = useState(traitValue);
   const [prevValue, setPrevValue] = useState(traitValue);
 
   const isNumber = (input: string) => {
-    if (typeof(input) !== "string") {
+    if (typeof input !== "string") {
       return false;
     }
     return !isNaN(Number(input)) && !isNaN(parseFloat(input));
-  }
+  };
 
-  const editTraitInline = (e: React.ChangeEvent<HTMLInputElement>, type: string) => {
-    if (type === 'rarity') {
+  const editTraitInline = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    type: string
+  ) => {
+    if (type === "rarity") {
       setNewValue({
         id: traitValue.id,
         name: newValue.name,
-        rarity: e.target.value
+        rarity: e.target.value,
       });
       return;
     }
@@ -39,16 +44,18 @@ export const TraitValuesRow: React.FC<Props> = ({
     setNewValue({
       id: traitValue.id,
       name: e.target.value,
-      rarity: newValue.rarity
+      rarity: newValue.rarity,
     });
     return;
-  }
+  };
 
-  const submitWithEnter = async (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === 'Enter') {
+  const submitWithEnter = async (
+    event: React.KeyboardEvent<HTMLInputElement>
+  ) => {
+    if (event.key === "Enter") {
       updateValues();
     }
-  }
+  };
 
   const updateValues = async () => {
     let data = newValue;
@@ -57,7 +64,7 @@ export const TraitValuesRow: React.FC<Props> = ({
       setNewValue({
         id: traitValue.id,
         name: prevValue.name,
-        rarity: newValue.rarity
+        rarity: newValue.rarity,
       });
       alert("Name cannot be blank.");
       return;
@@ -67,7 +74,7 @@ export const TraitValuesRow: React.FC<Props> = ({
       setNewValue({
         id: traitValue.id,
         name: newValue.name,
-        rarity: prevValue.rarity
+        rarity: prevValue.rarity,
       });
       alert("Rarity cannot be blank.");
       return;
@@ -79,7 +86,7 @@ export const TraitValuesRow: React.FC<Props> = ({
       setNewValue({
         id: traitValue.id,
         name: newValue.name,
-        rarity: prevValue.rarity
+        rarity: prevValue.rarity,
       });
       alert("Rarity must be a number between 0 and 1.");
       return;
@@ -93,7 +100,7 @@ export const TraitValuesRow: React.FC<Props> = ({
       setNewValue({
         id: traitValue.id,
         name: newValue.name,
-        rarity: prevValue.rarity
+        rarity: prevValue.rarity,
       });
       alert("Rarity must be a number between 0 and 1.");
       return;
@@ -107,7 +114,8 @@ export const TraitValuesRow: React.FC<Props> = ({
       collectionId,
       trait.id
     );
-  }
+    handleTraitValueChange(data as TraitValue);
+  };
 
   return (
     <>
@@ -116,11 +124,10 @@ export const TraitValuesRow: React.FC<Props> = ({
           <input
             className="p-2 input-value"
             value={newValue.name}
-            onChange={e => editTraitInline(e, "name")}
+            onChange={(e) => editTraitInline(e, "name")}
             onBlur={() => updateValues()}
             onKeyDown={(e) => submitWithEnter(e)}
-          >
-          </input>
+          ></input>
         </div>
       </td>
 
@@ -132,14 +139,13 @@ export const TraitValuesRow: React.FC<Props> = ({
             <input
               className="p-2 input-value"
               value={newValue.rarity}
-              onChange={e => editTraitInline(e, "rarity")}
+              onChange={(e) => editTraitInline(e, "rarity")}
               onBlur={() => updateValues()}
               onKeyDown={(e) => submitWithEnter(e)}
-            >
-            </input>
+            ></input>
           </div>
         </td>
       )}
     </>
   );
-}
+};

--- a/pages/projects/[projectId]/collections/[collectionId]/traits/[traitId]/index.tsx
+++ b/pages/projects/[projectId]/collections/[collectionId]/traits/[traitId]/index.tsx
@@ -36,12 +36,12 @@ export default function IndexPage(props: Props) {
   const projects = props.projects;
   const collection = props.collection;
   const trait = props.trait;
-  const traitValues = props.traitValues;
 
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [traitValueIdToDelete, setTraitValueIdToDelete] = useState<
     string | null
   >(null);
+  const [traitValues, setTraitValues] = useState(props.traitValues);
 
   const router = useRouter();
 
@@ -95,9 +95,23 @@ export default function IndexPage(props: Props) {
     router.reload();
   };
 
+  const handleTraitValueChange = (data: TraitValue) => {
+    const traitValuesCopy = [...traitValues];
+    traitValuesCopy.forEach((traitValue) => {
+      if (traitValue.id === data.id) {
+        traitValue.rarity = data.rarity;
+      }
+    });
+    setTraitValues(traitValuesCopy);
+  };
+
   const totalRarity =
     traitValues.length > 0
-      ? Number(traitValues.map((a) => a.rarity).reduce((a, b) => Number(a) + Number(b)))
+      ? Number(
+          traitValues
+            .map((a) => a.rarity)
+            .reduce((a, b) => Number(a) + Number(b))
+        )
       : 0;
   const noneRarity = 1 - totalRarity;
 
@@ -389,6 +403,7 @@ export default function IndexPage(props: Props) {
                                 projectId={project.id}
                                 collectionId={collection.id}
                                 trait={trait}
+                                handleTraitValueChange={handleTraitValueChange}
                               />
                               <td align="right">
                                 <Link
@@ -404,30 +419,30 @@ export default function IndexPage(props: Props) {
                                   }
                                   passHref={true}
                                 >
+                                  <a
+                                    href="#"
+                                    className="inline-block mr-2 text-indigo-600 hover:text-indigo-900"
+                                  >
+                                    <PencilAltIcon
+                                      className="w-5 h-5 text-gray-400"
+                                      aria-hidden="true"
+                                    />
+                                  </a>
+                                </Link>
                                 <a
                                   href="#"
+                                  onClick={(e) =>
+                                    confirmDeleteTraitValue(e, traitValue.id)
+                                  }
                                   className="inline-block mr-2 text-indigo-600 hover:text-indigo-900"
                                 >
-                                <PencilAltIcon
-                                  className="w-5 h-5 text-gray-400"
-                                  aria-hidden="true"
-                                />
+                                  <TrashIcon
+                                    className="w-5 h-5 text-gray-400"
+                                    aria-hidden="true"
+                                  />
                                 </a>
-                              </Link>
-                              <a
-                                href="#"
-                                onClick={(e) =>
-                                  confirmDeleteTraitValue(e, traitValue.id)
-                                }
-                                className="inline-block mr-2 text-indigo-600 hover:text-indigo-900"
-                              >
-                                <TrashIcon
-                                  className="w-5 h-5 text-gray-400"
-                                  aria-hidden="true"
-                                />
-                              </a>
-                            </td>
-                          </tr>
+                              </td>
+                            </tr>
                           );
                         })}
                       </tbody>


### PR DESCRIPTION
@cosimo-rip This PR addresses the feature listed in https://github.com/theskeletoncrew/treat-toolbox/issues/64 and https://github.com/theskeletoncrew/treat-toolbox/pull/58#issuecomment-1075546227   

Dynamically updating the Total Rarity and None Rarity when Trait Values are edited inline would allow users to instantly see the new ratios (without needing to refresh) and thereby improve their experience.      
    
To accomplish this, I created a function, **handleTraitValueChange**, passed to the TraitValuesRow component, which modifies the TraitValues array (now stored in state). This causes a re-render each time traits are edited inline to display the most up-to-date data.