### PR TITLE
fix odd checkbox behavior on traits

### DIFF
--- a/components/Forms/Trait/index.tsx
+++ b/components/Forms/Trait/index.tsx
@@ -233,9 +233,6 @@ export const TraitForm: React.FC<Props> = ({
                         id={"traitSet-" + traitSet.id}
                         {...register(`traitSetIds`, { value: [] })}
                         className="traitSetCheckbox shadow-sm sm:text-sm rounded-md border-transparent inline-block mr-2"
-                        defaultChecked={trait?.traitSetIds?.includes(
-                          traitSet.id
-                        )}
                         value={traitSet.id}
                       />
                       <label


### PR DESCRIPTION
Fixes https://github.com/theskeletoncrew/treat-toolbox/issues/59#issue-1146078792

Simply removing the `defaultChecked` prop does the trick! There was a conflict in setting the initial value due to using both `defaultValues` (which uses refs) in the `useForm` hook and `defaultChecked` when mapping to render the checkboxes. We can set the default values with either `defaultChecked` or `defaultValues`, but should not be using both methods in this uncontrolled input.